### PR TITLE
Update prep.cytonorm.R

### DIFF
--- a/R/prep.cytonorm.R
+++ b/R/prep.cytonorm.R
@@ -41,7 +41,8 @@ prep.cytonorm <- function(dat,
                        ydim = 5,
                        meta.k = 10, # can be 1, or >3
                        seed = 42,
-                       mem.ctrl = TRUE) {
+                       mem.ctrl = TRUE,
+                       nCells = 1000000) {
   
   ### Check that necessary packages are installed
       if(!is.element('Spectre', installed.packages()[,1])) stop('Spectre is required but not installed')
@@ -219,7 +220,7 @@ prep.cytonorm <- function(dat,
       
       fsom <- prepareFlowSOM(files,
                              colsToUse = cluster.cols,
-                             nCells = NULL, # Any subsampling is done prior to using this function
+                             nCells = nCells, # Any subsampling is done prior to using this function
                              FlowSOM.params = list(xdim = xdim,
                                                    ydim = ydim,
                                                    nClus = meta.k, 


### PR DESCRIPTION
Issues with data being handed over to prepareFlowSOM. I understand that nCells has been given NULL argument, as subsampling should be done beforehand if following the Spectre workflow. However, in this case, nCells=NULL causes removal of all observations. Therefore, the whole prep.cytonorm wrapper breaks and with an error along the lines of "argument is of length zero". I've suggested creating an nCells argument in the prep.cytonorm function - though there may be a more efficient or cleaner way to make this work while still making sense within the Spectre workflow.